### PR TITLE
Home Page Structure Of Getx Controller

### DIFF
--- a/lib/pages/home/presentation/views/home_view.dart
+++ b/lib/pages/home/presentation/views/home_view.dart
@@ -1,8 +1,5 @@
-
 import 'package:flutter/material.dart';
-import 'package:flutter_svg/svg.dart';
 import 'package:get/get.dart';
-import 'package:google_fonts/google_fonts.dart';
 import 'package:thepos/pages/home/presentation/controllers/home_controller.dart';
 
 class HomeView extends GetView<HomeController> {
@@ -10,12 +7,15 @@ class HomeView extends GetView<HomeController> {
 
   @override
   Widget build(BuildContext context) {
-    final controller = Get.put(HomeController());
-    return Scaffold(
-      body: Container(
-        color: Colors.blue,
-      ),
-    );
+    return GetBuilder<HomeController>(
+        init: HomeController(),
+        builder: (controller) {
+          return Scaffold(
+            body: Container(
+              color: Colors.blue,
+            ),
+          );
+        });
   }
 
 }


### PR DESCRIPTION
This commit try to redesign the structure of define the Getx Controller on Home Controller to be in code style of builder to use the controller later with OBX and builder in easier way.

In other hand , later in any other page you can define the controller without put and use the style like this commit way , or you can find the controller in this code structure with Get.find instead of HomeController() definition.